### PR TITLE
Update initialization order and remove version number.

### DIFF
--- a/Qualisys/QTMConnect/QTMConnect.uplugin
+++ b/Qualisys/QTMConnect/QTMConnect.uplugin
@@ -1,7 +1,5 @@
 {
   "FileVersion": 3,
-  "Version": 2,
-  "VersionName": "1.1",
   "FriendlyName": "QTM Connect For Unreal",
   "Description": "Real-time motion capture streaming from Qualisys Track Manager.",
   "Category": "Qualisys",
@@ -10,7 +8,6 @@
   "DocsURL": "https://www.qualisys.com/software/real-time-sdk/",
   "MarketplaceURL": "https://github.com/qualisys/Qualisys-Unreal-Plugin",
   "SupportURL": "https://www.qualisys.com/support/",
-  "EngineVersion": "4.21.0",
   "CanContainContent": false,
   "IsBetaVersion": false,
   "Installed": true,

--- a/Qualisys/QTMConnect/Source/QTMConnect/Private/QualisysClient.cpp
+++ b/Qualisys/QTMConnect/Source/QTMConnect/Private/QualisysClient.cpp
@@ -25,13 +25,13 @@
 
 AQualisysClient::AQualisysClient(const FObjectInitializer& ObjectInitializer) :
     Super(ObjectInitializer),
-    mRtProtocol(nullptr),
     AutoDiscoverQTMServer(true),
     IPAddressToQTMServer("127.0.0.1"),
     UdpPort(6789),
     StreamRate(0),
     DebugDrawingRigidBodies(false),
-    DebugDrawingTrajectories(false)
+    DebugDrawingTrajectories(false),
+    mRtProtocol(nullptr)
 {
     RootComponent = ObjectInitializer.CreateDefaultSubobject<USceneComponent>(this, TEXT("RootSceneComponent"));
 

--- a/Qualisys/QTMConnectLiveLink/QTMConnectLiveLink.uplugin
+++ b/Qualisys/QTMConnectLiveLink/QTMConnectLiveLink.uplugin
@@ -1,7 +1,5 @@
 {
   "FileVersion": 3,
-  "Version": 1,
-  "VersionName": "1.0",
   "FriendlyName": "QTMConnectLiveLink",
   "Description": "LiveLink Source for receiving Qualisys Track Manager skeleton data",
   "Category": "Qualisys",
@@ -10,7 +8,6 @@
   "DocsURL": "https://www.qualisys.com/software/real-time-sdk/",
   "MarketplaceURL": "https://github.com/qualisys/Qualisys-Unreal-Plugin",
   "SupportURL": "https://www.qualisys.com/support/",
-  "EngineVersion": "4.21.0",
   "CanContainContent": true,
   "IsBetaVersion": false,
   "Installed": false,

--- a/Qualisys/QTMConnectLiveLink/Source/QTMConnectLiveLink/Private/QTMConnectLiveLinkSource.cpp
+++ b/Qualisys/QTMConnectLiveLink/Source/QTMConnectLiveLink/Private/QTMConnectLiveLinkSource.cpp
@@ -18,9 +18,9 @@
 #pragma optimize("", off)
 
 FQTMConnectLiveLinkSource::FQTMConnectLiveLinkSource(const QTMConnectLiveLinkSettings& settings)
-    : Stopping(false)
+    : Settings(settings)
+    , Stopping(false)
     , Thread(nullptr)
-    , Settings(settings)
 {
     SourceType = LOCTEXT("QTMConnectLiveLinkSourceType", "QTM Connect LiveLink");
     SourceStatus = LOCTEXT("SourceStatus_NotConnected", "Not connected");


### PR DESCRIPTION
Change order of initialization to remove C5038 warning and remove version number in uproject