### PR TITLE
Safely close connection when Receive fails

### DIFF
--- a/Qualisys/QTMConnect/Source/QTMConnect/Private/QualisysClient.cpp
+++ b/Qualisys/QTMConnect/Source/QTMConnect/Private/QualisysClient.cpp
@@ -223,8 +223,16 @@ void AQualisysClient::TickActor(float DeltaTime, enum ELevelTick TickType, FActo
 
     CRTPacket::EPacketType packetType;
     auto ret = mRtProtocol->ReceiveRTPacket(packetType, false, 0);
-    if (ret <= 0)
+    if (ret == 0)
+    {
         return;
+    }
+    else if(ret < 0)
+    {
+        GLog->Logf(TEXT("AQualisysClient::TickActor: ReceiveRTPacket failed"));
+        ShutdownQualisysClient();
+        return;
+    }
 
     auto rtPacket = mRtProtocol->GetRTPacket();
     if (packetType == CRTPacket::PacketEvent)

--- a/Qualisys/QTMConnectLiveLink/Source/QTMConnectLiveLink/Private/QTMConnectLiveLinkSource.cpp
+++ b/Qualisys/QTMConnectLiveLink/Source/QTMConnectLiveLink/Private/QTMConnectLiveLinkSource.cpp
@@ -313,8 +313,24 @@ uint32 FQTMConnectLiveLinkSource::Run()
         }
 
         CRTPacket::EPacketType packetType;
-        if (mRTProtocol->ReceiveRTPacket(packetType, false, 1000) <= 0)
+        int result = mRTProtocol->ReceiveRTPacket(packetType, false, 1000);
+        if (result == 0)
+        {
             continue;
+        }
+        else if (result < 0)
+        {
+            if (startedStreaming)
+            {
+                DisconnectFromQTM();
+                autoDiscover = false;
+            }
+
+            ClearSubjects();
+            readSettings = false;
+            startedStreaming = false;
+            continue;
+        }
 
         if (packetType == CRTPacket::PacketEvent)
         {

--- a/Qualisys/QTMConnectLiveLink/Source/QTMConnectLiveLink/Private/QTMConnectLiveLinkSource.cpp
+++ b/Qualisys/QTMConnectLiveLink/Source/QTMConnectLiveLink/Private/QTMConnectLiveLinkSource.cpp
@@ -313,7 +313,7 @@ uint32 FQTMConnectLiveLinkSource::Run()
         }
 
         CRTPacket::EPacketType packetType;
-        if (mRTProtocol->ReceiveRTPacket(packetType, false, 0) <= 0)
+        if (mRTProtocol->ReceiveRTPacket(packetType, false, 1000) <= 0)
             continue;
 
         if (packetType == CRTPacket::PacketEvent)


### PR DESCRIPTION
Before we kept using the connection after receive failed which could cause the plugin to fail which then in turn would cause unreal to crash when it tried to interact with the plugin. 