### PR TITLE
Rigid bodies should be Transform Data

### DIFF
--- a/Qualisys/QTMConnectLiveLink/Source/QTMConnectLiveLink/Private/QTMConnectLiveLinkSource.cpp
+++ b/Qualisys/QTMConnectLiveLink/Source/QTMConnectLiveLink/Private/QTMConnectLiveLinkSource.cpp
@@ -4,6 +4,8 @@
 #include "ILiveLinkClient.h"
 #include "LiveLinkTypes.h"
 #include "Roles/LiveLinkAnimationRole.h"
+#include "Roles/LiveLinkTransformRole.h"
+#include "Roles/LiveLinkTransformTypes.h"
 
 #include "Windows/AllowWindowsPlatformTypes.h"
 #include "Windows/AllowWindowsPlatformAtomics.h"
@@ -498,10 +500,8 @@ uint32 FQTMConnectLiveLinkSource::Run()
                 const auto rigidBodyCount = packet->Get6DOFBodyCount();
                 for (unsigned int rigidBodyIndex = 0; rigidBodyIndex < rigidBodyCount; rigidBodyIndex++)
                 {
-                    FLiveLinkFrameDataStruct frameDataStruct = FLiveLinkFrameDataStruct(FLiveLinkAnimationFrameData::StaticStruct());
-                    FLiveLinkAnimationFrameData& subjectFrame = *frameDataStruct.Cast<FLiveLinkAnimationFrameData>();
-                    TArray<FTransform>& transforms = subjectFrame.Transforms;
-                    transforms.SetNumUninitialized(1);
+                    FLiveLinkFrameDataStruct frameDataStruct = FLiveLinkFrameDataStruct(FLiveLinkTransformFrameData::StaticStruct());
+                    FLiveLinkTransformFrameData& subjectFrame = *frameDataStruct.Cast<FLiveLinkTransformFrameData>();
 
                     float x, y, z;
                     float R[9];
@@ -516,7 +516,7 @@ uint32 FQTMConnectLiveLinkSource::Run()
                         FVector position(-x, y, z);
                         position *= positionScalingFactor;
                         FVector scale(1.0, 1.0, 1.0);
-                        transforms[0] = FTransform(FQuat(rotation.X, -rotation.Y, -rotation.Z, rotation.W), position, scale);
+                        subjectFrame.Transform = FTransform(FQuat(rotation.X, -rotation.Y, -rotation.Z, rotation.W), position, scale);
 
                         subjectFrame.WorldTime = worldTime;
                         subjectFrame.MetaData.SceneTime = sceneTime;
@@ -614,20 +614,8 @@ void FQTMConnectLiveLinkSource::CreateLiveLinkSubjects()
         {
             const FName name = mRTProtocol->Get6DOFBodyName(rigidBodyIndex);
 
-            TArray<FName> boneNames;
-            boneNames.SetNumUninitialized(1);
-            TArray<int32> boneParents;
-            boneParents.SetNumUninitialized(1);
-
-            boneNames[0] = "Bone";
-            boneParents[0] = -1;
-
-
-            FLiveLinkStaticDataStruct subjectDataStruct = FLiveLinkStaticDataStruct(FLiveLinkSkeletonStaticData::StaticStruct());
-            FLiveLinkSkeletonStaticData& subjectRefSkeleton = *subjectDataStruct.Cast<FLiveLinkSkeletonStaticData>();
-            subjectRefSkeleton.SetBoneNames(boneNames);
-            subjectRefSkeleton.SetBoneParents(boneParents);
-            Client->PushSubjectStaticData_AnyThread({ SourceGuid, name }, ULiveLinkAnimationRole::StaticClass(), MoveTemp(subjectDataStruct));
+            FLiveLinkStaticDataStruct subjectDataStruct = FLiveLinkStaticDataStruct(FLiveLinkTransformStaticData::StaticStruct());
+            Client->PushSubjectStaticData_AnyThread({ SourceGuid, name }, ULiveLinkTransformRole::StaticClass(), MoveTemp(subjectDataStruct));
 
             EncounteredSubjects.Add({ SourceGuid, name });
         }

--- a/README.md
+++ b/README.md
@@ -17,22 +17,27 @@ QTM Connect for Unreal is an Unreal plugin that supports streaming of skeleton, 
 3. The plugin should appear in the plugin window as "QTM Connect For Unreal". Click Enable and restart Unreal to get it activated.
 
 ## How to use the QTM Connect LiveLink plugin
-
+### Start live link source
 1. Start QTM in preview mode or file mode being sure there is a skeleton to stream. An example qtm file including a skeleton is provided in `.\Example Project`
 2. Enable `LiveLink` and `QTMConnectLiveLink` in Unreal under `Edit->Plugins`.
-3. Go to `Window->Live Link`, click `Add->QTM Connect LiveLink`, enter the QTM IP address and port and click ok.
-4. If the Skeleton of the Skeletal Mesh that you wish to animate matches the skeleton data being streamed from QTM (same bone names and hierarchy), then skip steps 5-7.
-5. In the Content Browser, click `Add New->Blueprint Class` and expand `All Classes` and search for `QualisysLiveLinkRetargetAsset`, and click `Select`.
-6. Double-click the retarget asset and go to `Details->Bone Mapping` and expand the `Bone Mapping` variable.
-7. In the right column, fill in the names of the Skeleton bones that best correspond to the QTM skeleton bones seen in the left column. If there is no corresponding 
+3. Go to `Window->Live Link`, click `Add->QTM Connect LiveLink`
+4. Enter the QTM IP address and port and click Create.
+### Stream skeleton data
+1. If the Skeleton of the Skeletal Mesh that you wish to animate matches the skeleton data being streamed from QTM (same bone names and hierarchy), then skip steps 5-7.
+2. In the Content Browser, click `Add New->Blueprint Class` and expand `All Classes` and search for `QualisysLiveLinkRetargetAsset`, and click `Select`.
+3. Double-click the retarget asset and go to `Details->Bone Mapping` and expand the `Bone Mapping` variable.
+4. In the right column, fill in the names of the Skeleton bones that best correspond to the QTM skeleton bones seen in the left column. If there is no corresponding 
    bone or the bone name already matches the QTM bone name, leave it as "None".
-8. In the Content Browser, go to the Skeletal Mesh that you wish to animate and `Right-click->Create->Anim Blueprint`. Give it a name and then double click on it.
-9. Right-click anywhere in the animation graph and search for the Live Link Pose node.
-10. Enter the subject name (the name of the skeleton being streamed from QTM), and connect the output pose to the input pose of the Final Animation Pose node.
-11. Click on the `Live Link Pose` node and go to `Details->Retarget->Retarget Asset` and select the retarget asset you created in step 5, or choose the QualisysLiveLinkRetargetAsset 
+5. In the Content Browser, go to the Skeletal Mesh that you wish to animate and `Right-click->Create->Anim Blueprint`. Give it a name and then double click on it.
+6. Right-click anywhere in the animation graph and search for the Live Link Pose node.
+7. Enter the subject name (the name of the skeleton being streamed from QTM), and connect the output pose to the input pose of the Final Animation Pose node.
+8. Click on the `Live Link Pose` node and go to `Details->Retarget->Retarget Asset` and select the retarget asset you created in step 5, or choose the QualisysLiveLinkRetargetAsset 
    if you skipped steps 5-7. 
-12. Click Compile, and you should see the mesh moving in the preview window. 
-13. Drag the animation blueprint you created in step 8 into your scene, then click Play.
+9. Click Compile, and you should see the mesh moving in the preview window. 
+10. Drag the animation blueprint you created in step 8 into your scene, then click Play.
+### Stream rigid body data
+1. Select your actor and Add Component `Live Link Controller`.
+2. Enter the rigid body name as subject name and `LiveLinkTransformRole` as role.
 
 *Note: Avoid mixing the LiveLink plugin data with the QualisysClient plugin. Synchronization of data might differ.*
 


### PR DESCRIPTION
### Rigid bodies should be Transform Data
---
1. Changes rigid bodies to use ULiveLinkTransformRole.
2. Also updated README on how to stream rigid body data.


![image](https://user-images.githubusercontent.com/37864286/101161257-a3d66900-3630-11eb-9713-a3b1acd4b4e3.png)

Note: I changed this to prepare for the [new Virtual camera](https://docs.unrealengine.com/en-US/WhatsNew/Builds/ReleaseNotes/4_26/index.html) in UE4.26. Which I presume wont work with skeletal data to drive transform.