### PR TITLE
.uplugin fix

### DIFF
--- a/Qualisys/QTMConnectLiveLink/QTMConnectLiveLink.uplugin
+++ b/Qualisys/QTMConnectLiveLink/QTMConnectLiveLink.uplugin
@@ -1,7 +1,7 @@
 {
 	"FileVersion": 3,
 	"Version": 0,
-	"VersionName": "",
+	"VersionName": "1.3",
 	"FriendlyName": "QTMConnectLiveLink",
 	"Description": "LiveLink Source for receiving Qualisys Track Manager skeleton data",
 	"Category": "Qualisys",
@@ -10,7 +10,6 @@
 	"DocsURL": "https://www.qualisys.com/software/real-time-sdk/",
 	"MarketplaceURL": "com.epicgames.launcher://ue/marketplace/product/f7c205bbe7894bffa2fe2289d8c81643",
 	"SupportURL": "https://www.qualisys.com/support/",
-	"EngineVersion": "5.0.0",
 	"CanContainContent": true,
 	"Installed": true,
 	"Modules": [
@@ -18,7 +17,7 @@
 			"Name": "QTMConnectLiveLink",
 			"Type": "Runtime",
 			"LoadingPhase": "Default",
-			"PlatformAllowList": [
+			"WhitelistPlatforms": [
 				"Win64"
 			]
 		},
@@ -26,7 +25,7 @@
 			"Name": "QTMConnectLiveLinkEditor",
 			"Type": "Editor",
 			"LoadingPhase": "Default",
-			"PlatformAllowList": [
+			"WhitelistPlatforms": [
 				"Win64"
 			]
 		}


### PR DESCRIPTION
- Added version number. This is only visible in the plugin desc. in the editor plugin menu.
- Removed Engine Version Tag - Will cause load warning when loading for other engine versions. Only ever needed in source code for Epic Marketplace.
- Despite Epic recommendations for UE5, PlatformAllowList is ignored by epic automated build. Whitelist still works for both in editor and automated builds, using both 4.x and 5.0. PlatformAllowList is UE5 only, will cause editor to try to build plugin for unsupported platforms when using 4.x versions.