### PR TITLE
Remove auto discover in favour for built in livelink presets

### DIFF
--- a/Qualisys/QTMConnectLiveLink/Source/QTMConnectLiveLink/Private/QTMConnectLiveLinkBlueprint.cpp
+++ b/Qualisys/QTMConnectLiveLink/Source/QTMConnectLiveLink/Private/QTMConnectLiveLinkBlueprint.cpp
@@ -6,7 +6,7 @@
 #include "Features/IModularFeatures.h"
 #include "QTMConnectLiveLinkSource.h"
 
-void UQTMConnectLiveLinkBlueprint::CreateQTMConnectLiveLinkSource(FString IpAddress, bool AutoDiscover, bool Stream3d, bool Stream6d, bool StreamSkeleton, bool StreamForce, FString StreamRate, int FrequencyValue, FLiveLinkSourceHandle& SourceHandle)
+void UQTMConnectLiveLinkBlueprint::CreateQTMConnectLiveLinkSource(FString IpAddress, bool Stream3d, bool Stream6d, bool StreamSkeleton, bool StreamForce, FString StreamRate, int FrequencyValue, FLiveLinkSourceHandle& SourceHandle)
 {
     IModularFeatures& ModularFeatures = IModularFeatures::Get();
 
@@ -17,7 +17,6 @@ void UQTMConnectLiveLinkBlueprint::CreateQTMConnectLiveLinkSource(FString IpAddr
 
         QTMConnectLiveLinkSettings settings;
         settings.IpAddress = IpAddress;
-        settings.AutoDiscover = AutoDiscover;
         settings.Stream3d = Stream3d;
         settings.Stream6d = Stream6d;
         settings.StreamSkeleton = StreamSkeleton;

--- a/Qualisys/QTMConnectLiveLink/Source/QTMConnectLiveLink/Public/QTMConnectLiveLinkBlueprint.h
+++ b/Qualisys/QTMConnectLiveLink/Source/QTMConnectLiveLink/Public/QTMConnectLiveLinkBlueprint.h
@@ -12,6 +12,6 @@ class QTMCONNECTLIVELINK_API UQTMConnectLiveLinkBlueprint : public UBlueprintFun
 {
     GENERATED_BODY()
 
-    UFUNCTION(BlueprintCallable, Category = "Qualisys", meta = (DisplayName = "Create QTM Connect LiveLink Source", IpAddress = "127.0.0.1", AutoDiscover = "true", Stream3d = "false", Stream6d = "true", StreamSkeleton = "true", StreamForce = "false", StreamRate = "All Frames", FrequencyValue = 0))
-    static void CreateQTMConnectLiveLinkSource(FString IpAddress, bool AutoDiscover, bool Stream3d, bool Stream6d, bool StreamSkeleton, bool StreamForce, FString StreamRate, int FrequencyValue, FLiveLinkSourceHandle& SourceHandle);
+    UFUNCTION(BlueprintCallable, Category = "Qualisys", meta = (DisplayName = "Create QTM Connect LiveLink Source", IpAddress = "127.0.0.1", Stream3d = "false", Stream6d = "true", StreamSkeleton = "true", StreamForce = "false", StreamRate = "All Frames", FrequencyValue = 0))
+    static void CreateQTMConnectLiveLinkSource(FString IpAddress, bool Stream3d, bool Stream6d, bool StreamSkeleton, bool StreamForce, FString StreamRate, int FrequencyValue, FLiveLinkSourceHandle& SourceHandle);
 };

--- a/Qualisys/QTMConnectLiveLink/Source/QTMConnectLiveLink/Public/QTMConnectLiveLinkSource.h
+++ b/Qualisys/QTMConnectLiveLink/Source/QTMConnectLiveLink/Public/QTMConnectLiveLinkSource.h
@@ -24,7 +24,7 @@ class CRTProtocol;
 class QTMCONNECTLIVELINK_API QTMConnectLiveLinkSettings
 {
 public:
-	QTMConnectLiveLinkSettings() : IpAddress("127.0.0.1"), AutoDiscover(false), Stream3d(false), Stream6d(true), StreamSkeleton(true), StreamForce(false), StreamRate("All Frames"), FrequencyValue(0)
+	QTMConnectLiveLinkSettings() : IpAddress("127.0.0.1"), Stream3d(false), Stream6d(true), StreamSkeleton(true), StreamForce(false), StreamRate("All Frames"), FrequencyValue(0)
 	{
 	}
 
@@ -32,7 +32,6 @@ public:
     FString ToString() const;
 
     FString IpAddress;
-	bool AutoDiscover;
 	bool Stream3d;
 	bool Stream6d;
 	bool StreamSkeleton;

--- a/Qualisys/QTMConnectLiveLink/Source/QTMConnectLiveLinkEditor/Private/QTMConnectLiveLinkSourceEditor.cpp
+++ b/Qualisys/QTMConnectLiveLink/Source/QTMConnectLiveLinkEditor/Private/QTMConnectLiveLinkSourceEditor.cpp
@@ -43,7 +43,6 @@ void SQTMConnectLiveLinkSourceEditor::Construct(const FArguments& Args)
                 [
                     SAssignNew(IpAddress, SEditableTextBox)
                     .Text(LOCTEXT("DefaultQTMIpAddress", "127.0.0.1"))
-                    .IsEnabled(&SQTMConnectLiveLinkSourceEditor::IsAutoConnect)
                 ]
             ]
 

--- a/Qualisys/QTMConnectLiveLink/Source/QTMConnectLiveLinkEditor/Private/QTMConnectLiveLinkSourceEditor.cpp
+++ b/Qualisys/QTMConnectLiveLink/Source/QTMConnectLiveLinkEditor/Private/QTMConnectLiveLinkSourceEditor.cpp
@@ -35,27 +35,6 @@ void SQTMConnectLiveLinkSourceEditor::Construct(const FArguments& Args)
                 .FillWidth(0.5f)
                 [
                     SNew(STextBlock)
-                    .Text(LOCTEXT("AutoDiscover", "Auto Discover"))
-                ]
-                + SHorizontalBox::Slot()
-                .HAlign(HAlign_Fill)
-                .FillWidth(0.5f)
-                [
-                    SAssignNew(AutoDiscoverCB, SCheckBox)
-                    .IsChecked(ECheckBoxState::Checked)
-                ]
-            ]
-
-            + SVerticalBox::Slot()
-            .AutoHeight()
-            .Padding(3.0f)
-            [
-                SNew(SHorizontalBox)
-                + SHorizontalBox::Slot()
-                .HAlign(HAlign_Left)
-                .FillWidth(0.5f)
-                [
-                    SNew(STextBlock)
                     .Text(LOCTEXT("QTMIpAddress", "QTM Server IP Address"))
                 ]
                 + SHorizontalBox::Slot()
@@ -226,7 +205,6 @@ FReply SQTMConnectLiveLinkSourceEditor::CreateSource() const
 {
     QTMConnectLiveLinkSettings settings;
     settings.IpAddress = this->GetIpAddress();
-    settings.AutoDiscover = this->GetAutoDiscover();
     settings.Stream3d = this->GetStream3d();
     settings.Stream6d = this->GetStream6d();
     settings.StreamSkeleton = this->GetStreamSkeleton();

--- a/Qualisys/QTMConnectLiveLink/Source/QTMConnectLiveLinkEditor/Private/QTMConnectLiveLinkSourceEditor.cpp
+++ b/Qualisys/QTMConnectLiveLink/Source/QTMConnectLiveLinkEditor/Private/QTMConnectLiveLinkSourceEditor.cpp
@@ -20,8 +20,8 @@ void SQTMConnectLiveLinkSourceEditor::Construct(const FArguments& Args)
     ChildSlot
     [
         SNew(SBox)
-        .WidthOverride(250)
-        .HeightOverride(230)
+        .WidthOverride(300)
+        .HeightOverride(210)
         [
             SNew(SVerticalBox)
 

--- a/Qualisys/QTMConnectLiveLink/Source/QTMConnectLiveLinkEditor/Private/QTMConnectLiveLinkSourceEditor.h
+++ b/Qualisys/QTMConnectLiveLink/Source/QTMConnectLiveLinkEditor/Private/QTMConnectLiveLinkSourceEditor.h
@@ -44,11 +44,6 @@ class QTMCONNECTLIVELINKEDITOR_API SQTMConnectLiveLinkSourceEditor : public SCom
         return IpAddress.Get()->GetText().ToString();
     }
 
-    bool GetAutoDiscover() const
-    {
-        return IsAutoConnect();
-    }
-
     bool GetStream3d() const
     {
         return IsStream3d();
@@ -85,16 +80,10 @@ private:
     TArray<TSharedPtr<FString>> StreamRates;
     TSharedPtr<SEditableText> FrequencyValueText;
     TSharedPtr<SEditableTextBox> FrequencyValueTB;
-    TSharedPtr<SCheckBox> AutoDiscoverCB;
     TSharedPtr<SCheckBox> Stream3dCB;
     TSharedPtr<SCheckBox> Stream6dCB;
     TSharedPtr<SCheckBox> StreamSkeletonCB;
     TSharedPtr<SCheckBox> StreamForceCB;
-
-    bool IsAutoConnect() const
-    {
-        return AutoDiscoverCB->IsChecked();
-    }
 
     bool IsStream3d() const
     {


### PR DESCRIPTION
###Remove auto discover in favour for built in livelink presets
- There were some issues with it
- It was default selected which made the issues more apparent and disturbed the workflow