### PR TITLE
Fixed invalid docs url

### DIFF
--- a/Qualisys/QTMConnectLiveLink/QTMConnectLiveLink.uplugin
+++ b/Qualisys/QTMConnectLiveLink/QTMConnectLiveLink.uplugin
@@ -7,7 +7,7 @@
 	"Category": "Qualisys",
 	"CreatedBy": "Qualisys",
 	"CreatedByURL": "https://www.qualisys.com/",
-	"DocsURL": "https://www.qualisys.com/software/real-time-sdk/",
+	"DocsURL": "https://github.com/qualisys/QTM-Connect-For-Unreal/",
 	"MarketplaceURL": "com.epicgames.launcher://ue/marketplace/product/f7c205bbe7894bffa2fe2289d8c81643",
 	"SupportURL": "https://www.qualisys.com/support/",
 	"CanContainContent": true,


### PR DESCRIPTION
The docs URL was pointing to a 404 address. Redirected it to the github repo.
![image](https://github.com/user-attachments/assets/8235acc0-0d0c-4366-bb63-e8abb550067a)
