### PR TITLE
Fixes build error when building from within a project

### DIFF
--- a/Qualisys/QTMConnectLiveLink/Source/QTMConnectLiveLink/Public/QualisysLiveLinkRetargetAsset.h
+++ b/Qualisys/QTMConnectLiveLink/Source/QTMConnectLiveLink/Public/QualisysLiveLinkRetargetAsset.h
@@ -5,6 +5,7 @@
 #include "BoneIndices.h"
 #include "CoreMinimal.h"
 #include "LiveLinkRetargetAsset.h"
+#include "Roles/LiveLinkAnimationTypes.h"
 #include "BonePose.h"
 #include "QualisysLiveLinkRetargetAsset.generated.h"
 


### PR DESCRIPTION
# Issue
Some type information was missing when building the plugin from an Unreal 5.5 Project

# Solution
Added the relevant header
