### PR TITLE
Add Multi-Platform Support (Win64, Mac, Linux) and Build-From-Source Docs

### DIFF
--- a/Qualisys/QTMConnectLiveLink/QTMConnectLiveLink.uplugin
+++ b/Qualisys/QTMConnectLiveLink/QTMConnectLiveLink.uplugin
@@ -18,10 +18,10 @@
 			"Type": "Runtime",
 			"LoadingPhase": "Default",
 			"WhitelistPlatforms": [
-				"Win64"
+				"Win64","Linux","Mac"
 			],
 			"BlacklistPlatforms":[
-				"Android","Linux","Mac","IOS"
+				"Android","IOS"
 			]
 		},
 		{
@@ -29,10 +29,10 @@
 			"Type": "UncookedOnly",
 			"LoadingPhase": "Default",
 			"WhitelistPlatforms": [
-				"Win64"
+				"Win64","Linux","Mac"
 			],
 			"BlacklistPlatforms":[
-				"Android","Linux","Mac","IOS"
+				"Android","IOS"
 			]
 		}
 	],

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 QTM Connect for Unreal is an Unreal plugin that supports streaming of skeleton, rigid body, marker, force and timecode data between Qualisys Track Manager and Unreal Engine.
 
 ## Installation of the plugin
-You can find the plugin on Unreal Engine Marketplace [here](https://www.fab.com/listings/0be18c14-a8d8-40fb-8932-89d07fc9774c)
+You can find the plugin on Unreal Engine Marketplace [HERE](https://www.fab.com/listings/0be18c14-a8d8-40fb-8932-89d07fc9774c)
 
 ## How to use the QTM Connect LiveLink plugin
 ### Start live link source
@@ -94,5 +94,5 @@ Note: In most cases, you can simply install and use this plugin directly from th
    - Launch the Unreal Editor and open your `.uproject` file.  
    - When prompted, allow Unreal to rebuild your plugin automatically.  
    - After the rebuild completes, the plugin should be available for use in your project.
-   - Open the Plugins view (`Edit -> Plugins`) enable ``QTMConnectLiveLink``
+   - Open the Plugins view (`Edit -> Plugins`). Enable ``QTMConnectLiveLink``
  

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ QTM Connect for Unreal is an Unreal plugin that supports streaming of skeleton, 
 ## Installation of the plugin
 You can find the plugin on unreal engine marketplace [here](https://www.unrealengine.com/marketplace/en-US/product/qualisys-qtm-connect-live-link)
 
+
 ## How to use the QTM Connect LiveLink plugin
 ### Start live link source
 1. Start QTM in preview mode or file mode being sure there is a skeleton to stream. An example qtm file including a skeleton is provided in `.\Example Project`
@@ -43,3 +44,57 @@ https://www.qualisys.com/my/qacademy/#!/tutorials/how-to-use-the-skeleton-solver
 ## Supported Unreal Build Platforms
 
 * Windows 64bit
+* MacOS
+* Linux
+
+
+
+## Building the Plugin with Unreal Engine
+Note: In most cases, you can simply install and use this plugin directly from the Unreal Marketplace. The instructions below are for those who need or prefer to build the plugin from source (e.g., for custom development or modifications).
+1. **Set Up Your Environment**  
+   - Make sure your environment is ready to [build plugins](https://dev.epicgames.com/community/learning/tutorials/qz93/unreal-engine-building-plugins).  
+   - Use a C++ Unreal Engine project and have the necessary SDKs installed (e.g., Visual Studio on Windows, Xcode on macOS, etc.).
+
+2. **Clone This Repository (With Submodules)**  
+   - **Important**: **Do not** clone it **inside** your existing UE project folder. Pick a separate directory.  
+   - Example:
+     ```bash
+     git clone --recurse-submodules https://github.com/qualisys/QTM-Connect-For-Unreal.git
+     ```
+   - If you already cloned without submodules, run:
+     ```bash
+     cd QTM-Connect-For-Unreal
+     git submodule update --init --recursive
+     ```
+
+3. **Run the Copy Script**  
+  This script copies necessary files from the `qualisys_cpp_sdk` submodule into the plugin’s internal directories.
+   - On **Windows**:
+     ```cmd
+     .\copy_sdk.bat
+     ```
+   - On **macOS/Linux**:
+        ```bash
+        chmod +x copy_sdk.sh
+        ./copy_sdk.sh
+        ```
+
+1. **Copy the `Qualisys` Folder to Your UE Project’s `Plugins` Folder**  
+   - Copy the entire `Qualisys` folder (for example, `Qualisys/QTMConnectLiveLink`) to your UE project’s `Plugins` folder.  
+   - If a `Plugins` folder does not exist in your project, create one at the root of the project directory.  
+   - Your final structure might look like this:
+     ```
+     YourProject
+     ┣━ Plugins
+     ┃  ┗━ Qualisys
+     ┃     ┗━ QTMConnectLiveLink
+     ┃        ┣━ Source
+     ┃        ┣━ ...
+     ┣━ Source
+     ┣━ YourProject.uproject
+     ```
+
+2. **Open the Project in Unreal Engine**  
+   - Launch the Unreal Editor and open your `.uproject` file.  
+   - When prompted, allow Unreal to rebuild your plugin automatically.  
+   - After the rebuild completes, the plugin should be available for use in your project.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,8 @@
 # QTM Connect for Unreal
-
 QTM Connect for Unreal is an Unreal plugin that supports streaming of skeleton, rigid body, marker, force and timecode data between Qualisys Track Manager and Unreal Engine.
 
 ## Installation of the plugin
 You can find the plugin on unreal engine marketplace [here](https://www.unrealengine.com/marketplace/en-US/product/qualisys-qtm-connect-live-link)
-
 
 ## How to use the QTM Connect LiveLink plugin
 ### Start live link source
@@ -12,6 +10,7 @@ You can find the plugin on unreal engine marketplace [here](https://www.unrealen
 2. Enable `LiveLink` and `QTMConnectLiveLink` in Unreal under `Edit->Plugins`.
 3. Go to `Window->Live Link`, click `Add->QTM Connect LiveLink`
 4. Enter the QTM IP address and port and click Create.
+
 ### Stream skeleton data
 1. If the Skeleton of the Skeletal Mesh that you wish to animate matches the skeleton data being streamed from QTM (same bone names and hierarchy), then skip steps 5-7.
 2. In the Content Browser, click `Add New->Blueprint Class` and expand `All Classes` and search for `QualisysLiveLinkRetargetAsset`, and click `Select`.
@@ -25,6 +24,7 @@ You can find the plugin on unreal engine marketplace [here](https://www.unrealen
    if you skipped steps 5-7. 
 9. Click Compile, and you should see the mesh moving in the preview window. 
 10. Drag the animation blueprint you created in step 8 into your scene, then click Play.
+
 ### Stream rigid body data
 1. Select your actor and Add Component `Live Link Controller`.
 2. Enter the rigid body name as subject name and `LiveLinkTransformRole` as role.
@@ -38,16 +38,12 @@ You can find the plugin on unreal engine marketplace [here](https://www.unrealen
 *Note: Avoid mixing the LiveLink plugin data with the QualisysClient plugin. Synchronization of data might differ.*
 
 ## Video tutorial: How to use the Skeleton Solver with Unreal
-
 https://www.qualisys.com/my/qacademy/#!/tutorials/how-to-use-the-skeleton-solver-with-unreal
 
 ## Supported Unreal Build Platforms
-
 * Windows 64bit
 * MacOS
 * Linux
-
-
 
 ## Building the Plugin with Unreal Engine
 Note: In most cases, you can simply install and use this plugin directly from the Unreal Marketplace. The instructions below are for those who need or prefer to build the plugin from source (e.g., for custom development or modifications).
@@ -70,16 +66,16 @@ Note: In most cases, you can simply install and use this plugin directly from th
 3. **Run the Copy Script**  
   This script copies necessary files from the `qualisys_cpp_sdk` submodule into the plugin’s internal directories.
    - On **Windows**:
-     ```cmd
-     .\copy_sdk.bat
-     ```
+      ```cmd
+      qualisys_cpp_sdk_init.bat
+      ```
    - On **macOS/Linux**:
-        ```bash
-        chmod +x copy_sdk.sh
-        ./copy_sdk.sh
-        ```
+      ```bash
+      chmod +x qualisys_cpp_sdk_init.sh
+      ./qualisys_cpp_sdk_init.sh
+      ```
 
-1. **Copy the `Qualisys` Folder to Your UE Project’s `Plugins` Folder**  
+4. **Copy the `Qualisys` Folder to Your UE Project’s `Plugins` Folder**  
    - Copy the entire `Qualisys` folder (for example, `Qualisys/QTMConnectLiveLink`) to your UE project’s `Plugins` folder.  
    - If a `Plugins` folder does not exist in your project, create one at the root of the project directory.  
    - Your final structure might look like this:
@@ -94,7 +90,7 @@ Note: In most cases, you can simply install and use this plugin directly from th
      ┣━ YourProject.uproject
      ```
 
-2. **Open the Project in Unreal Engine**  
+5. **Open the Project in Unreal Engine**  
    - Launch the Unreal Editor and open your `.uproject` file.  
    - When prompted, allow Unreal to rebuild your plugin automatically.  
    - After the rebuild completes, the plugin should be available for use in your project.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 QTM Connect for Unreal is an Unreal plugin that supports streaming of skeleton, rigid body, marker, force and timecode data between Qualisys Track Manager and Unreal Engine.
 
 ## Installation of the plugin
-You can find the plugin on unreal engine marketplace [here](https://www.unrealengine.com/marketplace/en-US/product/qualisys-qtm-connect-live-link)
+You can find the plugin on Unreal Engine Marketplace [here](https://www.fab.com/listings/0be18c14-a8d8-40fb-8932-89d07fc9774c)
 
 ## How to use the QTM Connect LiveLink plugin
 ### Start live link source
@@ -29,7 +29,7 @@ You can find the plugin on unreal engine marketplace [here](https://www.unrealen
 1. Select your actor and Add Component `Live Link Controller`.
 2. Enter the rigid body name as subject name and `LiveLinkTransformRole` as role.
 
-**Note: If you want to stream your rigid body as an camera role prefix the rigid body name with `cam_` (eg. `cam_rigidbody`)**
+**Note: If you want to stream your rigid body as a camera role prefix the rigid body name with `cam_` (eg. `cam_rigidbody`)**
 
 ### Stream force data
 1. Each force plate is a livelink subject with the `basic` role. 
@@ -46,7 +46,7 @@ https://www.qualisys.com/my/qacademy/#!/tutorials/how-to-use-the-skeleton-solver
 * Linux
 
 ## Building the Plugin with Unreal Engine
-Note: In most cases, you can simply install and use this plugin directly from the Unreal Marketplace. The instructions below are for those who need or prefer to build the plugin from source (e.g., for custom development or modifications).
+Note: In most cases, you can simply install and use this plugin directly from the Unreal Engine Marketplace. The instructions below are for those who need or prefer to build the plugin from source (e.g., for custom development or modifications).
 1. **Set Up Your Environment**  
    - Make sure your environment is ready to [build plugins](https://dev.epicgames.com/community/learning/tutorials/qz93/unreal-engine-building-plugins).  
    - Use a C++ Unreal Engine project and have the necessary SDKs installed (e.g., Visual Studio on Windows, Xcode on macOS, etc.).
@@ -94,3 +94,5 @@ Note: In most cases, you can simply install and use this plugin directly from th
    - Launch the Unreal Editor and open your `.uproject` file.  
    - When prompted, allow Unreal to rebuild your plugin automatically.  
    - After the rebuild completes, the plugin should be available for use in your project.
+   - Open the Plugins view (`Edit -> Plugins`) enable ``QTMConnectLiveLink``
+ 

--- a/qualisys_cpp_sdk_init.sh
+++ b/qualisys_cpp_sdk_init.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+# The target directory for copied files
+dir_private="Qualisys/QTMConnectLiveLink/Source/QTMConnectLiveLink/Private/RTClientSDK"
+
+# Files to copy
+files=(
+    "Markup.cpp"
+    "Network.cpp"
+    "RTPacket.cpp"
+    "RTProtocol.cpp"
+    "Markup.h"
+    "Network.h"
+    "RTPacket.h"
+    "RTProtocol.h"
+)
+
+echo "Ensuring directory exists..."
+mkdir -p "$dir_private"
+
+echo "Copying files from qualisys_cpp_sdk into $dir_private"
+
+# Loop over files array and copy each into $dir_private
+for file in "${files[@]}"; do
+    cp -f "qualisys_cpp_sdk/$file" "$dir_private"
+done
+
+echo "Done copying files from qualisys_cpp_sdk into $dir_private"


### PR DESCRIPTION
This PR extends the plugin's supported systems from Win64-only to Win64, macOS, and Linux. It also introduces a `.sh` script for Unix-based platforms to complement the existing `.bat` file, along with updated documentation on how to build the plugin from source. The new docs explain repository cloning (with submodules), running the appropriate copy script on any operating system, and integrating the plugin into a UE project. While most users can still install directly from the Unreal Marketplace, these changes make it easier for anyone who needs to customize or develop the plugin on multiple platforms.