### PR TITLE
Updated qualisys_cpp_sdk and init scripts

### DIFF
--- a/Qualisys/QTMConnectLiveLink/Source/QTMConnectLiveLink/Private/QTMConnectLiveLinkSource.cpp
+++ b/Qualisys/QTMConnectLiveLink/Source/QTMConnectLiveLink/Private/QTMConnectLiveLinkSource.cpp
@@ -339,17 +339,17 @@ uint32 FQTMConnectLiveLinkSource::Run()
                 components |= CRTProtocol::cComponentForceSingle;
             }
             
-            CRTProtocol::EStreamRate streamRate = CRTProtocol::RateAllFrames;
+            CRTProtocol::EStreamRate streamRate = CRTProtocol::EStreamRate::RateAllFrames;
             if (Settings.StreamRate == "Frequency") 
             {
-                streamRate = CRTProtocol::RateFrequency;
+                streamRate = CRTProtocol::EStreamRate::RateFrequency;
             }
             else if (Settings.StreamRate == "Frequency Divisor") 
             {
-                streamRate = CRTProtocol::RateFrequencyDivisor;
+                streamRate = CRTProtocol::EStreamRate::RateFrequencyDivisor;
             }
 
-            if (!mRTProtocol->StreamFrames(streamRate, (streamRate != CRTProtocol::RateAllFrames) ? Settings.FrequencyValue : 0, 0, nullptr, components))
+            if (!mRTProtocol->StreamFrames(streamRate, (streamRate != CRTProtocol::EStreamRate::RateAllFrames) ? Settings.FrequencyValue : 0, 0, nullptr, components))
             {
                 SourceStatus = FText::FromString(ANSI_TO_TCHAR(mRTProtocol->GetErrorString()));
 

--- a/Qualisys/QTMConnectLiveLink/Source/QTMConnectLiveLink/QTMConnectLiveLink.Build.cs
+++ b/Qualisys/QTMConnectLiveLink/Source/QTMConnectLiveLink/QTMConnectLiveLink.Build.cs
@@ -8,22 +8,25 @@ public class QTMConnectLiveLink : ModuleRules
     public QTMConnectLiveLink(ReadOnlyTargetRules Target) : base(Target)
     {
         PCHUsage = ModuleRules.PCHUsageMode.UseExplicitOrSharedPCHs;
-        string pluginPublicIncludePath = Path.Combine(ModuleDirectory, "Public");
-        string pluginPrivateIncludePath = Path.Combine(ModuleDirectory, "Private");
+
+        bWarningsAsErrors = false;
+
+        bEnableExceptions = true;
+
+        ShadowVariableWarningLevel = WarningLevel.Off;
 
         PublicIncludePaths.AddRange(
             new string[] {
-                pluginPublicIncludePath
+                Path.Combine(ModuleDirectory, "Public")
             }
         );
 
         PrivateIncludePaths.AddRange(
             new string[] {
-                pluginPrivateIncludePath
+                Path.Combine(ModuleDirectory, "Private"),
+                Path.Combine(ModuleDirectory, "Private/RtClientSDK/External/tinyxml2")
             }
         );
-
-        bEnableExceptions = true;
 
         PublicDependencyModuleNames.AddRange(
             new string[]

--- a/qualisys_cpp_sdk_init.bat
+++ b/qualisys_cpp_sdk_init.bat
@@ -1,20 +1,33 @@
 @echo off
 
 set "dir_private=Qualisys\QTMConnectLiveLink\Source\QTMConnectLiveLink\Private\RTClientSDK"
-
-echo Ensuring directories exist...
-if not exist "%dir_private%" (
-    mkdir "%dir_private%"
-    echo Created %dir_private%
-)
-
+echo Ensuring directory exists...
+if not exist "%dir_private%" mkdir "%dir_private%"
 echo Copying files from qualisys_cpp_sdk into %dir_private%
-copy /Y "qualisys_cpp_sdk\Markup.cpp" "%dir_private%"
-copy /Y "qualisys_cpp_sdk\Network.cpp" "%dir_private%"
-copy /Y "qualisys_cpp_sdk\RTPacket.cpp" "%dir_private%"
-copy /Y "qualisys_cpp_sdk\RTProtocol.cpp" "%dir_private%"
-copy /Y "qualisys_cpp_sdk\Markup.h" "%dir_private%"
-copy /Y "qualisys_cpp_sdk\Network.h" "%dir_private%"
-copy /Y "qualisys_cpp_sdk\RTPacket.h" "%dir_private%"
-copy /Y "qualisys_cpp_sdk\RTProtocol.h" "%dir_private%"
+xcopy /Y "qualisys_cpp_sdk\Deserializer.cpp" "%dir_private%\"
+xcopy /Y "qualisys_cpp_sdk\Deserializer.h" "%dir_private%\"
+xcopy /Y "qualisys_cpp_sdk\LICENSE.md" "%dir_private%\"
+xcopy /Y "qualisys_cpp_sdk\Network.cpp" "%dir_private%\"
+xcopy /Y "qualisys_cpp_sdk\Network.h" "%dir_private%\"
+xcopy /Y "qualisys_cpp_sdk\RTPacket.cpp" "%dir_private%\"
+xcopy /Y "qualisys_cpp_sdk\RTPacket.h" "%dir_private%\"
+xcopy /Y "qualisys_cpp_sdk\RTProtocol.cpp" "%dir_private%\"
+xcopy /Y "qualisys_cpp_sdk\RTProtocol.h" "%dir_private%\"
+xcopy /Y "qualisys_cpp_sdk\Serializer.cpp" "%dir_private%\"
+xcopy /Y "qualisys_cpp_sdk\Serializer.h" "%dir_private%\"
+xcopy /Y "qualisys_cpp_sdk\Settings.cpp" "%dir_private%\"
+xcopy /Y "qualisys_cpp_sdk\Settings.h" "%dir_private%\"
+xcopy /Y "qualisys_cpp_sdk\SettingsDeserializer.cpp" "%dir_private%\"
+xcopy /Y "qualisys_cpp_sdk\SettingsDeserializer.h" "%dir_private%\"
+xcopy /Y "qualisys_cpp_sdk\SettingsSerializer.cpp" "%dir_private%\"
+xcopy /Y "qualisys_cpp_sdk\SettingsSerializer.h" "%dir_private%\"
 echo Done copying files from qualisys_cpp_sdk into %dir_private%
+
+set "tinyxml2_private=Qualisys\QTMConnectLiveLink\Source\QTMConnectLiveLink\Private\RTClientSDK\External\tinyxml2"
+echo Ensuring directory exists...
+if not exist "%tinyxml2_private%" mkdir "%tinyxml2_private%"
+echo Copying files from qualisys_cpp_sdk into %tinyxml2_private%
+xcopy /Y "qualisys_cpp_sdk\External\tinyxml2\LICENSE.txt" "%tinyxml2_private%\"
+xcopy /Y "qualisys_cpp_sdk\External\tinyxml2\tinyxml2.cpp" "%tinyxml2_private%\"
+xcopy /Y "qualisys_cpp_sdk\External\tinyxml2\tinyxml2.h" "%tinyxml2_private%\"
+echo Done copying files from qualisys_cpp_sdk into %tinyxml2_private%

--- a/qualisys_cpp_sdk_init.sh
+++ b/qualisys_cpp_sdk_init.sh
@@ -1,28 +1,34 @@
-#!/usr/bin/env bash
+#!/bin/bash
+set -e  # Exit on error
 
-# The target directory for copied files
 dir_private="Qualisys/QTMConnectLiveLink/Source/QTMConnectLiveLink/Private/RTClientSDK"
-
-# Files to copy
-files=(
-    "Markup.cpp"
-    "Network.cpp"
-    "RTPacket.cpp"
-    "RTProtocol.cpp"
-    "Markup.h"
-    "Network.h"
-    "RTPacket.h"
-    "RTProtocol.h"
-)
-
 echo "Ensuring directory exists..."
 mkdir -p "$dir_private"
-
 echo "Copying files from qualisys_cpp_sdk into $dir_private"
-
-# Loop over files array and copy each into $dir_private
-for file in "${files[@]}"; do
-    cp -f "qualisys_cpp_sdk/$file" "$dir_private"
-done
-
+cp -u "qualisys_cpp_sdk/Deserializer.cpp" "$dir_private/"
+cp -u "qualisys_cpp_sdk/Deserializer.h" "$dir_private/"
+cp -u "qualisys_cpp_sdk/LICENSE.md" "$dir_private/"
+cp -u "qualisys_cpp_sdk/Network.cpp" "$dir_private/"
+cp -u "qualisys_cpp_sdk/Network.h" "$dir_private/"
+cp -u "qualisys_cpp_sdk/RTPacket.cpp" "$dir_private/"
+cp -u "qualisys_cpp_sdk/RTPacket.h" "$dir_private/"
+cp -u "qualisys_cpp_sdk/RTProtocol.cpp" "$dir_private/"
+cp -u "qualisys_cpp_sdk/RTProtocol.h" "$dir_private/"
+cp -u "qualisys_cpp_sdk/Serializer.cpp" "$dir_private/"
+cp -u "qualisys_cpp_sdk/Serializer.h" "$dir_private/"
+cp -u "qualisys_cpp_sdk/Settings.cpp" "$dir_private/"
+cp -u "qualisys_cpp_sdk/Settings.h" "$dir_private/"
+cp -u "qualisys_cpp_sdk/SettingsDeserializer.cpp" "$dir_private/"
+cp -u "qualisys_cpp_sdk/SettingsDeserializer.h" "$dir_private/"
+cp -u "qualisys_cpp_sdk/SettingsSerializer.cpp" "$dir_private/"
+cp -u "qualisys_cpp_sdk/SettingsSerializer.h" "$dir_private/"
 echo "Done copying files from qualisys_cpp_sdk into $dir_private"
+
+tinyxml2_private="Qualisys/QTMConnectLiveLink/Source/QTMConnectLiveLink/Private/RTClientSDK/External/tinyxml2/"
+echo "Ensuring directory exists..."
+mkdir -p "$tinyxml2_private"
+echo "Copying files from qualisys_cpp_sdk into $tinyxml2_private"
+cp -u "qualisys_cpp_sdk/External/tinyxml2/LICENSE.txt" "$tinyxml2_private/"
+cp -u "qualisys_cpp_sdk/External/tinyxml2/tinyxml2.cpp" "$tinyxml2_private/"
+cp -u "qualisys_cpp_sdk/External/tinyxml2/tinyxml2.h" "$tinyxml2_private/"
+echo "Done copying files from qualisys_cpp_sdk into $tinyxml2_private"


### PR DESCRIPTION
# Updates `qualisys_cpp_sdk`

Note: The latest version of `qualisys_cpp_sdk` includes the third party code `tinyxml2.cpp`, `tinyxml2.h`

Issue:
	The inclusion of tinyxml2 generates warning C4459
	Engine\Source\Runtime\Core\Public\Math\RotationTranslationMatrix.h(60):
		error C4459: declaration of 'CR' hides global declaration

Solution:
	Disabled shadow variable warning in QTMConnectLiveLink.Build.cs
