### PR TITLE
Fix Mac build casing + trigger Azure build on release tags (v1.9.1)

### DIFF
--- a/Qualisys/QTMConnectLiveLink/QTMConnectLiveLink.uplugin
+++ b/Qualisys/QTMConnectLiveLink/QTMConnectLiveLink.uplugin
@@ -1,7 +1,7 @@
 {
 	"FileVersion": 3,
 	"Version": 0,
-	"VersionName": "1.6.2",
+	"VersionName": "1.9.1",
 	"FriendlyName": "QTMConnectLiveLink",
 	"Description": "LiveLink Source for receiving Qualisys Track Manager skeleton data",
 	"Category": "Qualisys",

--- a/Qualisys/QTMConnectLiveLink/Source/QTMConnectLiveLinkEditor/Private/QTMConnectLiveLinkSourceEditor.h
+++ b/Qualisys/QTMConnectLiveLink/Source/QTMConnectLiveLinkEditor/Private/QTMConnectLiveLinkSourceEditor.h
@@ -2,7 +2,7 @@
 //
 #pragma once
 
-#include "QtmConnectLiveLinkSource.h"
+#include "QTMConnectLiveLinkSource.h"
 
 #include "Widgets/SCompoundWidget.h"
 #include "Widgets/Views/SListView.h"

--- a/pipeline-github.yml
+++ b/pipeline-github.yml
@@ -1,5 +1,10 @@
-trigger: 
-- main
+trigger:
+  branches:
+    include:
+    - master
+  tags:
+    include:
+    - 'v*'
 
 pool: Unreal
 


### PR DESCRIPTION
Two changes:

**1. Fix Fab Mac build failure.** `QTMConnectLiveLinkSourceEditor.h` included `"QtmConnectLiveLinkSource.h"` (`Qtm`); Epic's Fab Mac farm uses a case-sensitive filesystem, so it failed to resolve against the real header `QTMConnectLiveLinkSource.h`. Win64/default-macOS builds never caught it. Also bumps `VersionName` `1.6.2 → 1.9.1`.

**2. Auto-run the Azure build on release tags (native trigger).** Adds a `tags: ['v*']` filter to `pipeline-github.yml` so pushing a release tag queues Azure pipeline 69 (`sw-unreal-plugin-github-hook`) through the **existing GitHub service connection** — no new GitHub credentials. Also corrects the stale `main → master` CI filter.

⚠️ **Requires** removing pipeline 69's UI-level trigger override in the Azure DevOps pipeline editor (Triggers → uncheck *Override the YAML trigger from here*), otherwise the YAML triggers stay masked.